### PR TITLE
Fixed `prepend`

### DIFF
--- a/examples/Cantor.hs
+++ b/examples/Cantor.hs
@@ -63,9 +63,11 @@ _Natural = dimap (ana enum) (fmap (cata denum)) where
     (nq, nr) = divMod n 2
 
   shift :: Bool -> Functional -> Functional
-  shift b f = f . prepend b
-    prepend b _ 0 = b
-    prepend _ a n = a (n-1)
+  shift b f = f . prepend b 
+    
+  prepend :: Bool -> Cantor -> Natural -> Bool
+  prepend bb _ 0 = bb 
+  prepend _ a n = a (n-1)
 
   getConst :: Functional -> Maybe Bool
   getConst f

--- a/examples/Cantor.hs
+++ b/examples/Cantor.hs
@@ -65,7 +65,7 @@ _Natural = dimap (ana enum) (fmap (cata denum)) where
   shift :: Bool -> Functional -> Functional
   shift b f = f . prepend b 
     
-  prepend :: Bool -> Cantor -> Natural -> Bool
+  prepend :: Bool -> Cantor -> Cantor 
   prepend bb _ 0 = bb 
   prepend _ a n = a (n-1)
 


### PR DESCRIPTION
It now compiles although I'm still having `Pattern match(es) are non-exhaustive`