### PR TITLE
Update dependency bound for transformers from 0.5 to 0.6

### DIFF
--- a/hyperfunctions.cabal
+++ b/hyperfunctions.cabal
@@ -32,7 +32,7 @@ library
     base                >= 4.7   && < 5,
     distributive        >= 0.4.4 && < 1,
     profunctors         >= 5     && < 6,
-    transformers        >= 0.3   && < 0.5
+    transformers        >= 0.3   && < 0.6
 
   hs-source-dirs: src
 


### PR DESCRIPTION
It works for me at transformers 5.6.2